### PR TITLE
non-hostapp: fix up retry count non-integer issue

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -353,7 +353,7 @@ function in_container_hostapp_update {
     local target_docker_cmd
     local target_dockerd
     local volumes_args=()
-    local retrycount=0
+    local -i retrycount=0
     local tmp_image
 
     stop_services


### PR DESCRIPTION
since the variable is not set as an integer, we are simply appending to
the string rather than incrementing the value:

```
[000000009][WARNING]Couldn't pull docker image, was try #0...
[000000019][WARNING]Couldn't pull docker image, was try #01...
```

Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>