### PR TITLE
supervisor: wait for upgrade unit to complete

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -221,7 +221,7 @@ function upgrade_supervisor() {
                     progress 90 "Running supervisor update"
                     stop_services
                     # use a transient unit in order to namespace-collide with a potential API-initiated update
-                    supervisor_update='systemd-run --unit run-update-supervisor update-resin-supervisor'
+                    supervisor_update='systemd-run --wait --unit run-update-supervisor update-resin-supervisor'
                     if version_gt "${VERSION_ID}" "${minimum_supervisor_stop}"; then
                         supervisor_update+=' -n'
                     fi


### PR DESCRIPTION
currently there are occasions when a supervisor upgrade does not
complete before the HUP reboots a device. this causes confusion when the
supervisor eventually does update 15 minutes after boot.

Connects-to: https://github.com/balena-os/balenahup/issues/300
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>