### PR TITLE
meta: remove legacy codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@samothx @saintaardvark @xginn8 @camerondiver
+*	@samothx @xginn8 @camerondiver


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>