### PR TITLE
private DTs: do not log out from the registry until cleanup

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -825,6 +825,9 @@ function finish_up() {
     fi
 
     sync
+
+    DOCKER_HOST="unix:///var/run/${DOCKER_CMD}-host.sock" ${DOCKER_CMD} logout "${REGISTRY_ENDPOINT}" > /dev/null 2>&1 || true
+
     if [ "${NOREBOOT}" == "no" ]; then
         # Reboot into new OS
         log "Rebooting into new OS in 5 seconds..."
@@ -1201,7 +1204,6 @@ if version_gt "${VERSION_ID}" "${minimum_hostapp_target_version}" ||
     if [ -z "${image}" ]; then
         log ERROR "all hostapp-update attempts have failed..."
     fi
-    DOCKER_HOST="unix:///var/run/${DOCKER_CMD}-host.sock" ${DOCKER_CMD} logout "${REGISTRY_ENDPOINT}" > /dev/null 2>&1
 
     if [ "${LEGACY_UPDATE}" = "yes" ]; then
         upgrade_supervisor "${image}" no_docker_host


### PR DESCRIPTION
since older OSes get a sideloaded balenaOS hostapp, it is untagged in
the local image store. when we crack that image open to find our new
target supervisor, we have to contact the upstream registry and retag
our local image with the registry reference. in order to do that, we
must remain logged in.

Connects-to: #331
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>