### PR TITLE
upgrade-2.x: apply jetson fix to OS < v2.84.7

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -527,7 +527,7 @@ function hostapp_based_update {
             ;;
         jetson-tx2)
             log "Running pre-update fixes for ${SLUG}"
-            if version_gt "${HOST_OS_VERSION}" "2.31.1" && version_gt "2.58.3" "${target_version}" ; then
+            if version_gt "${HOST_OS_VERSION}" "2.31.1" && version_gt "2.84.7" "${target_version}" ; then
                 export JETSON_FIX=1
                 pre_update_jetson_fix
             fi


### PR DESCRIPTION
A mistyped path in the hostapp-update hooks in meta-balena caused the
extlinux.conf file to not be persisted across HUP, causing variables set
in the config to be reset by the supervisor, triggering untimely reboots
during upgrades.

A fix has been made to meta-balena [0] to properly persist the
configuration across a HUP, but this will require an OS upgrade to take
effect.

The supervisor has a similar fix in place to prevent reboots when
healthcheck breadcrumbs are present, but this requires a new supervisor
release.

To cover devices that are running older supervisor releases on older OS
versions, extend the version check to apply the Jetson fix to affected
OS versions.

[0] https://github.com/balena-os/meta-balena/commit/096024808224aea2100e2a2a1f95ef75e23493ef

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>