### PR TITLE
Backport increased os_bc_limit to existing releases

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -363,6 +363,13 @@ function post_update_jetson_fix {
             echo "extra_os_cmdline=${APPEND_value}" >> "${uEnv_file}" && sync "${uEnv_file}"
         fi
     fi
+
+    if [ -e "${uEnv_file}" ] && grep -q '^os_bc_lim=' "${uEnv_file}"; then
+        log "Fix for jetson-tx2 bootcount limit already applied"
+    else
+        echo "os_bc_lim=3" >>  "${uEnv_file}" && sync "${uEnv_file}"
+        log "Applied fix for jetson-tx2 bootcount limit to extra_uEnv.txt"
+    fi
 }
 
 #######################################


### PR DESCRIPTION
Starting with BalenaOS v2.85.9 the u-boot bootcount limit
has been increased to 3. Let's apply this fix previous
jetson-tx2 releases, like 2.73 or 2.82.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>