### PR TITLE
Stop reading the storage driver from the boot partition

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -521,8 +521,10 @@ function hostapp_based_update {
     local balena_migration=no
     local inactive_used
     local hostapp_image_count
-    local storage_driver
-    storage_driver=$(cat /boot/storage-driver)
+    storage_driver=overlay2
+    if [ -f /boot/storage-driver ]; then
+        storage_driver=$(cat /boot/storage-driver)
+    fi
 
     case ${SLUG} in
         raspberry*)

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -589,7 +589,7 @@ function hostapp_based_update {
             hostapp_image_count=$(DOCKER_HOST="unix:///var/run/${DOCKER_CMD}-host.sock" ${DOCKER_CMD} images -q | wc -l)
             if [ "$hostapp_image_count" -eq "0" ]; then
                 # There are no hostapp images, but space is still taken up
-                local target_folder="${inactive}/${DOCKER_CMD}/${storage_driver}/"
+                local target_folder="${inactive}/${DOCKER_CMD}/"
                 log "Found potential leftover data, cleaning ${target_folder}"
                 systemctl stop "${DOCKER_CMD}-host"
                 find "$target_folder" -mindepth 1 -maxdepth 1 -exec rm -r "{}" \; || true


### PR DESCRIPTION
This has been removed with the aufs to overlay2 transition.

Needs to check that HUPs between an aufs based OS and an overlay2 based one stills spaws the docker daemon with the correct storage engine.

Resolves: https://github.com/balena-os/balenahup/issues/372