### PR TITLE
upgrade-2.x: Allow upgrading from balenaOS v3.x

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -1069,7 +1069,7 @@ log "OS variant: ${HOST_OS_VERSION}"
 
 # Check host OS version
 case $VERSION in
-    2.*|2[0-9][0-9][0-9].*.*)
+    [2-9].*|2[0-9][0-9][0-9].*.*)
         log "Host OS version \"$VERSION\" OK."
         ;;
     *)


### PR DESCRIPTION
We need this for newer balenaOS devices which
we plan to release, for example the Jetson Orin
Nano wich will have the first production image on
balenaOS 3.x, as well as for the devices which will be updated
in the future to 3.x and newer

Change-type: patch