### PR TITLE
upgrade-2.x failure reporting

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -778,13 +778,23 @@ function get_image_location() {
     image=$(CURL_CA_BUNDLE=${TMPCRT} curl --retry 10 --silent -X GET \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer ${APIKEY}" \
-        "${API_ENDPOINT}/v6/release?\$select=id&\$expand=contains__image/image&\$filter=(belongs_to__application/any(a:a/is_for__device_type/any(dt:dt/slug%20eq%20'${SLUG}')%20and%20is_host%20eq%20true))%20and%20is_final%20eq%20true%20and%20is_invalidated%20eq%20false%20and%20(release_tag/any(rt:(rt/tag_key%20eq%20'version')%20and%20(rt/value%20eq%20'${version}')))%20and%20((release_tag/any(rt:(rt/tag_key%20eq%20'variant')%20and%20(rt/value%20eq%20'${variant_tag}')))%20or%20not(release_tag/any(rt:rt/tag_key%20eq%20'variant')))" \
+        "${API_ENDPOINT}/v6/release?\$select=id&\$expand=contains__image/image&\$filter=(belongs_to__application/any(a:a/is_for__device_type/any(dt:dt/slug%20eq%20'${SLUG}')%20and%20is_host%20eq%20true))%20and%20is_final%20eq%20true%20and%20is_invalidated%20eq%20false%20and%20raw_version%20eq%20'${version}'" \
         | jq -r "[.d[] | .contains__image[0].image[0] | [.is_stored_at__image_location, .content_hash] | \"\(.[0])@\(.[1])\"]")
     if echo "${image}" | jq -e '. | length == 1' > /dev/null; then
         echo "${image}" | jq -r '.[0]'
     else
-        # we should only get one result, something is wrong
-        echo
+        # Try with version and variant labels for backwards compatibility
+        image=$(CURL_CA_BUNDLE=${TMPCRT} curl --retry 10 --silent -X GET \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${APIKEY}" \
+            "${API_ENDPOINT}/v6/release?\$select=id&\$expand=contains__image/image&\$filter=(belongs_to__application/any(a:a/is_for__device_type/any(dt:dt/slug%20eq%20'${SLUG}')%20and%20is_host%20eq%20true))%20and%20is_final%20eq%20true%20and%20is_invalidated%20eq%20false%20and%20(release_tag/any(rt:(rt/tag_key%20eq%20'version')%20and%20(rt/value%20eq%20'${version}')))%20and%20((release_tag/any(rt:(rt/tag_key%20eq%20'variant')%20and%20(rt/value%20eq%20'${variant_tag}')))%20or%20not(release_tag/any(rt:rt/tag_key%20eq%20'variant')))" \
+            | jq -r "[.d[] | .contains__image[0].image[0] | [.is_stored_at__image_location, .content_hash] | \"\(.[0])@\(.[1])\"]")
+        if echo "${image}" | jq -e '. | length == 1' > /dev/null; then
+            echo "${image}" | jq -r '.[0]'
+        else
+            # we should only get one result, something is wrong
+            echo
+        fi
     fi
 }
 

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -154,9 +154,18 @@ function version_gt() {
 function compare_device_state() {
     perc=$1
     state=$2
+    local resp
+    local remote_perc
+    local remote_state
     resp=$(CURL_CA_BUNDLE=${TMPCRT} curl --silent --retry 10 --header "Authorization: Bearer ${APIKEY}" \
         "${API_ENDPOINT}/v6/device(uuid='${UUID}')?\$select=provisioning_state,provisioning_progress" | jq '.d[]')
-    test "${perc}" -eq "$(echo "${resp}" | jq -r '.provisioning_progress')" && test "${state}" = "$(echo "${resp}" | jq -r '.provisioning_state')"
+    remote_perc=$(echo "${resp}" | jq -r '.provisioning_progress')
+    remote_state=$(echo "${resp}" | jq -r '.provisioning_state')
+    if [ -n "${remote_perc}" ] && [ -n "${remote_state}" ]; then
+        test "${perc}" -eq "${remote_perc}" && test "${state}" = "${remote_state}"
+    else
+        return 1
+    fi
 }
 
 function stop_services() {

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -293,7 +293,7 @@ function remove_sample_wifi {
 function pre_update_pi_bootfiles_removal {
     local boot_files_for_removal=('start_db.elf' 'fixup_db.dat')
     for f in "${boot_files_for_removal[@]}"; do
-        echo "Removing $f from boot partition"
+        log "Removing $f from boot partition"
         rm -f "/mnt/boot/$f"
     done
     sync /mnt/boot

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -1075,8 +1075,6 @@ else
     log ERROR "No target OS version specified."
 fi
 
-log "OS variant: ${HOST_OS_VERSION}"
-
 # Check host OS version
 case $VERSION in
     [2-9].*|2[0-9][0-9][0-9].*.*)

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -852,7 +852,7 @@ function get_image_location() {
     image=$(CURL_CA_BUNDLE=${TMPCRT} curl --retry 10 --silent -X GET \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer ${APIKEY}" \
-        "${API_ENDPOINT}/v6/release?\$select=id&\$expand=contains__image/image&\$filter=(belongs_to__application/any(a:a/is_for__device_type/any(dt:dt/slug%20eq%20'${SLUG}')%20and%20is_host%20eq%20true))%20and%20is_final%20eq%20true%20and%20is_invalidated%20eq%20false%20and%20raw_version%20eq%20'${version}'" \
+        "${API_ENDPOINT}/v6/release?\$select=id&\$expand=contains__image/image&\$filter=(belongs_to__application/any(a:a/is_for__device_type/any(dt:dt/slug%20eq%20'${SLUG}')%20and%20is_host%20eq%20true))%20and%20is_invalidated%20eq%20false%20and%20raw_version%20eq%20'${version}'" \
         | jq -r "[.d[] | .contains__image[0].image[0] | [.is_stored_at__image_location, .content_hash] | \"\(.[0])@\(.[1])\"]")
     if echo "${image}" | jq -e '. | length == 1' > /dev/null; then
         echo "${image}" | jq -r '.[0]'
@@ -861,7 +861,7 @@ function get_image_location() {
         image=$(CURL_CA_BUNDLE=${TMPCRT} curl --retry 10 --silent -X GET \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${APIKEY}" \
-            "${API_ENDPOINT}/v6/release?\$select=id&\$expand=contains__image/image&\$filter=(belongs_to__application/any(a:a/is_for__device_type/any(dt:dt/slug%20eq%20'${SLUG}')%20and%20is_host%20eq%20true))%20and%20is_final%20eq%20true%20and%20is_invalidated%20eq%20false%20and%20(release_tag/any(rt:(rt/tag_key%20eq%20'version')%20and%20(rt/value%20eq%20'${version}')))%20and%20((release_tag/any(rt:(rt/tag_key%20eq%20'variant')%20and%20(rt/value%20eq%20'${variant_tag}')))%20or%20not(release_tag/any(rt:rt/tag_key%20eq%20'variant')))" \
+            "${API_ENDPOINT}/v6/release?\$select=id&\$expand=contains__image/image&\$filter=(belongs_to__application/any(a:a/is_for__device_type/any(dt:dt/slug%20eq%20'${SLUG}')%20and%20is_host%20eq%20true))%20and%20is_invalidated%20eq%20false%20and%20(release_tag/any(rt:(rt/tag_key%20eq%20'version')%20and%20(rt/value%20eq%20'${version}')))%20and%20((release_tag/any(rt:(rt/tag_key%20eq%20'variant')%20and%20(rt/value%20eq%20'${variant_tag}')))%20or%20not(release_tag/any(rt:rt/tag_key%20eq%20'variant')))" \
             | jq -r "[.d[] | .contains__image[0].image[0] | [.is_stored_at__image_location, .content_hash] | \"\(.[0])@\(.[1])\"]")
         if echo "${image}" | jq -e '. | length == 1' > /dev/null; then
             echo "${image}" | jq -r '.[0]'


### PR DESCRIPTION
* Allow draft updates
* Use `raw_version` for image location fetch and fallback to `version` label
* Improve error reporting to cloud with the use of a signal trap handler

Relates-to: https://github.com/balena-os/meta-balena/issues/3257