### PR TITLE
upgrade-2.x: Block draft version upgrades using the release_tag version

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -929,11 +929,13 @@ function get_image_location() {
     if echo "${image}" | jq -e '. | length == 1' > /dev/null; then
         echo "${image}" | jq -r '.[0]'
     else
+        # TODO: Remove this release_tag fallback once the API migrates all hostApp release versions to the `release.semver` field.
+        # See: https://github.com/balena-io/balena-api/pull/4821
         # Try with version and variant labels for backwards compatibility
         image=$(CURL_CA_BUNDLE="${TMPCRT}" ${CURL} \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${APIKEY}" \
-            "${API_ENDPOINT}/v6/release?\$select=id&\$expand=contains__image/image&\$filter=(belongs_to__application/any(a:a/is_for__device_type/any(dt:dt/slug%20eq%20'${SLUG}')%20and%20is_host%20eq%20true))%20and%20is_invalidated%20eq%20false%20and%20(release_tag/any(rt:(rt/tag_key%20eq%20'version')%20and%20(rt/value%20eq%20'${version}')))%20and%20((release_tag/any(rt:(rt/tag_key%20eq%20'variant')%20and%20(rt/value%20eq%20'${variant_tag}')))%20or%20not(release_tag/any(rt:rt/tag_key%20eq%20'variant')))" \
+            "${API_ENDPOINT}/v6/release?\$select=id&\$expand=contains__image/image&\$filter=(belongs_to__application/any(a:a/is_for__device_type/any(dt:dt/slug%20eq%20'${SLUG}')%20and%20is_host%20eq%20true))%20and%20is_final%20eq%20true%20and%20is_invalidated%20eq%20false%20and%20(release_tag/any(rt:(rt/tag_key%20eq%20'version')%20and%20(rt/value%20eq%20'${version}')))%20and%20((release_tag/any(rt:(rt/tag_key%20eq%20'variant')%20and%20(rt/value%20eq%20'${variant_tag}')))%20or%20not(release_tag/any(rt:rt/tag_key%20eq%20'variant')))" \
             | jq -r "[.d[] | .contains__image[0].image[0] | [.is_stored_at__image_location, .content_hash] | \"\(.[0])@\(.[1])\"]")
         if echo "${image}" | jq -e '. | length == 1' > /dev/null; then
             echo "${image}" | jq -r '.[0]'


### PR DESCRIPTION
Atm given a draft OS release 3.2.1-2345, users would be able to HUP to it via both
* `device os-update 3.2.1-2345`, in which case the script finds the version via the `raw_version` field
* and `device os-update 3.2.1`, in which case the script find the version via the `release_tag`

After this, HUPing to draft-OS releases will only work using the `raw_version` which removes the ambiguity and block users from accidentally HUPing to a draft release (eg they misstype the patch version or on purpose try to increase it to check whether a new version is out).

Partially reverts commit ce70f31ba4bda575fef4fecf0e50ac1eb3a1d8cf.

Change-type: patch

See: https://balena.fibery.io/Work/Improvement/Remove-hostApp-version-release-tag-dependency-from-API-1412