### PR TITLE
don't force exit if reaching delta server fails

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -994,7 +994,7 @@ function find_delta() {
         delta=$(CURL_CA_BUNDLE="${TMPCRT}" ${CURL} \
             "${DELTA_ENDPOINT}/api/v${DELTA_VERSION}/delta?src=${src_image}&dest=${target_image}" \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${delta_token}" | jq -r '.name')
+            -H "Authorization: Bearer ${delta_token}" | jq -r '.name') || true
         if [ -n "${delta}" ]; then
             echo "${delta}"
         fi


### PR DESCRIPTION
Change-type: patch


Currently if reaching the delta server fails, the script exits - when it should fall back onto a non-delta update. This attempts to fix that. The idea is instead of exiting due to a nonzero exit-code, the script will continue with an empty value for the delta image, so then this https://github.com/balena-os/balenahup/blob/ryan/catch-delta-fail/upgrade-2.x.sh#L1276C12-L1276C23 will evaluate as fale, and the script continue with a non-delta upgrade