### PR TITLE
Check that active and inactive partitions differ

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -693,6 +693,18 @@ function hostapp_based_update {
         storage_driver=$(cat /boot/storage-driver)
     fi
 
+    local active_part_dev
+    local inactive_part_dev
+
+    active_part_dev=$(df -P /mnt/sysroot/active | tail -1 | awk '{print $1}')
+    inactive_part_dev=$(df -P /mnt/sysroot/inactive | tail -1 | awk '{print $1}')
+
+    # Check that the inactive partition is not the same as active.
+    # This avoids any issues with partitions being mislabled leading to a bricked device.
+    if [[ "${active_part_dev}" = "${inactive_part_dev}" ]]; then
+        log ERROR "Active and inactive partitions are the same, bailing out..."
+    fi
+
     # remove REC files on boot partition
     remove_rec_files
 


### PR DESCRIPTION
This avoids any issues with partitions being mislabeled leading to a bricked device.

Change-type: patch
See: https://balena.fibery.io/Inputs/Pattern/Generic-x86_64-GPT-with-sw-RAID1-fails-HUP-4508
See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Several-self-hosted-GitHub-runners-unresponsive-after-failed-HUP-23