### PR TITLE
Resolve part UUID links returned by df

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -696,8 +696,9 @@ function hostapp_based_update {
     local active_part_dev
     local inactive_part_dev
 
-    active_part_dev=$(df -P /mnt/sysroot/active | tail -1 | awk '{print $1}')
-    inactive_part_dev=$(df -P /mnt/sysroot/inactive | tail -1 | awk '{print $1}')
+    # Resolve the active and inactive partition devices and canonicalize links
+    active_part_dev=$(df -P /mnt/sysroot/active | tail -1 | awk '{print $1}' | xargs readlink -f)
+    inactive_part_dev=$(df -P /mnt/sysroot/inactive | tail -1 | awk '{print $1}' | xargs readlink -f)
 
     # Check that the inactive partition is not the same as active.
     # This avoids any issues with partitions being mislabled leading to a bricked device.


### PR DESCRIPTION
On some device types, the df command will return
a part UUID instead of the root device name.

This fixes the expected behaviour on Generic AARCH64 devices.

Change-type: patch
See: https://github.com/balena-os/balenahup/pull/405
See: https://balena.fibery.io/Inputs/Pattern/Generic-x86_64-GPT-with-sw-RAID1-fails-HUP-4508
See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Several-self-hosted-GitHub-runners-unresponsive-after-failed-HUP-23